### PR TITLE
Minor fixup

### DIFF
--- a/_layouts/default.md
+++ b/_layouts/default.md
@@ -6,7 +6,6 @@
     <meta charset='utf-8'>
     <link rel="stylesheet" type="text/css" href="/stylesheets/stylesheet.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="/stylesheets/pygment_trac.css" media="screen" />
-    <link rel="stylesheet" type="text/css" href="/stylesheets/print.css" media="print" />
     <title>sup</title>
     <meta name="viewport" content="width=device-width" />
   </head>


### PR DESCRIPTION
- Use `<meta name="viewport">`, making the page a little more mobile-friendly
- Remove dead `<link>` pointing to print.css
